### PR TITLE
RHDENG-2656: Clean Up Drupal Database

### DIFF
--- a/_docker/drupal/drupal-filesystem/db-migrations/20181227161400_remove_duplicate_url_aliases_migration.php
+++ b/_docker/drupal/drupal-filesystem/db-migrations/20181227161400_remove_duplicate_url_aliases_migration.php
@@ -1,0 +1,26 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class RemoveDuplicateUrlAliasesMigration extends AbstractMigration
+{
+    /**
+     * Deletes rows from the lightning_url_aliases table with duplicate values
+     * for the source and alias columns, such that only one row of each set of
+     * duplicates remains. Arbitrarily, this will be the row with the lowest
+     * pid.
+     */
+	public function up()
+    {
+		$this->execute("DELETE FROM lightning_url_alias WHERE pid IN (
+            SELECT i.pid
+            FROM (SELECT * FROM lightning_url_alias) AS i
+            INNER JOIN (
+                SELECT k.source, min(k.pid) as minId
+                FROM (SELECT * FROM lightning_url_alias) AS k
+                GROUP BY k.source, k.alias
+                HAVING COUNT(*) > 1
+            ) AS j ON i.source=j.source WHERE i.pid > j.minId
+		);");
+    }
+}


### PR DESCRIPTION
This commit cleans up the lightning_url_alias table by deleting
row that have duplicate source, alias column values while retaining
one such row with the lowest pid value.

### JIRA Issue Link
* Link to the JIRA ticket(s) this pull request solves

### Verification Process
<!--
What process should a tester use to verify this pull request closes the JIRA ticket?

- Which page(s) should one visit?
- Which buttons to click?
- What is the expected outcome?
- etc.
-->
