### PR TITLE
Export OpenID Keycloak config

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/openid_connect.settings.keycloak.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/openid_connect.settings.keycloak.yml
@@ -1,21 +1,14 @@
-enabled: false
+enabled: keycloak
 settings:
-  client_id: null
-  client_secret: null
+  redirect_url: ''
+  client_id: ''
+  client_secret: ''
   keycloak_base: 'https://example.com/auth'
   keycloak_realm: example_realm
   authorization_endpoint_kc: 'https://example.com/auth/realms/example-realm/protocol/openid-connect/auth'
   token_endpoint_kc: 'https://example.com/auth/realms/example-realm/protocol/openid-connect/token'
   userinfo_endpoint_kc: 'https://example.com/auth/realms/example-realm/protocol/openid-connect/userinfo'
-  sign_out_endpoint_kc: 'https://example.com/auth/realms/example-realm/protocol/openid-connect/logout'
-  check_session_iframe_kc: 'https://example.com/auth/realms/example-realm/protocol/openid-connect/login-status-iframe.html'
+  userinfo_update_email: 0
   keycloak_i18n: false
-  keycloak_i18n_mapping:
-    -
-      langcode: zh-hans
-      target: zh-CN
-    -
-      langcode: zh-hant
-      target: zh-HK
 _core:
   default_config_hash: tHgaZtYNBvFIKvqZfcFO3ymqz_OJFnSAaPGXkBAFElw

--- a/_docker/drupal/drupal-filesystem/web/config/sync/openid_connect.settings.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/openid_connect.settings.yml
@@ -1,5 +1,5 @@
 always_save_userinfo: true
-connect_existing_users: false
+connect_existing_users: true
 override_registration_settings: false
 userinfo_mappings:
   timezone: zoneinfo

--- a/_docker/drupal/drupal-filesystem/web/config/sync/openid_connect.settings.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/openid_connect.settings.yml
@@ -3,5 +3,11 @@ connect_existing_users: false
 override_registration_settings: false
 userinfo_mappings:
   timezone: zoneinfo
+  metatag: 0
+  path: 0
+  field_long_bio: 0
+  field_short_bio: 0
+  field_user_photo: 0
+  field_user_title: 0
 _core:
   default_config_hash: kli1Xws0l--Y-jy-9ZTGApFO_EFk9DMawoetjMk76Ro


### PR DESCRIPTION
This exports the config required to enable Keycloak as a provider via
config.

### JIRA Issue Link
* https://issues.jboss.org/browse/RHDENG-2752

### Verification Process

* Keycloak should be an enabled OpenID/SSO provider after importing Drupal config