### PR TITLE
Provide a config override warning on Keycloak

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/openid_connect.settings.keycloak.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/openid_connect.settings.keycloak.yml
@@ -1,13 +1,13 @@
 enabled: keycloak
 settings:
   redirect_url: ''
-  client_id: ''
-  client_secret: ''
-  keycloak_base: 'https://example.com/auth'
-  keycloak_realm: example_realm
-  authorization_endpoint_kc: 'https://example.com/auth/realms/example-realm/protocol/openid-connect/auth'
-  token_endpoint_kc: 'https://example.com/auth/realms/example-realm/protocol/openid-connect/token'
-  userinfo_endpoint_kc: 'https://example.com/auth/realms/example-realm/protocol/openid-connect/userinfo'
+  client_id: 'Set with config override: check rhd.settings.yml'
+  client_secret: 'Set with config override: check rhd.settings.yml'
+  keycloak_base: 'Set with config override: check rhd.settings.yml'
+  keycloak_realm: 'Set with config override: check rhd.settings.yml'
+  authorization_endpoint_kc: 'Set with config override: check rhd.settings.yml'
+  token_endpoint_kc: 'Set with config override: check rhd.settings.yml'
+  userinfo_endpoint_kc: 'Set with config override: check rhd.settings.yml'
   userinfo_update_email: 0
   keycloak_i18n: false
 _core:


### PR DESCRIPTION
This provides a value in Keycloak config values (strings) of "Set with
config override: check rhd.settings.yml" so that admins, viewing the
config form in the UI, will know that these config values are set using
config overrides. Without this warning, it would appear that the config
is set improperly since the config override values do not display on the
config forms.

### JIRA Issue Link
* https://issues.jboss.org/browse/RHDENG-2752

### Verification Process

* The OpenID config form (`/admin/config/services/openid-connect`), under the Keycloak configuration section, should display values of "Set with
config override: check rhd.settings.yml" for config values that are strings. These values are set using Drupal 8 config overrides, so this will provide a warning to admin