### PR TITLE
Change Keycloak button text, make button evident

### DIFF
--- a/_docker/drupal/drupal-filesystem/change-keycloak-button-text.patch
+++ b/_docker/drupal/drupal-filesystem/change-keycloak-button-text.patch
@@ -1,0 +1,40 @@
+diff --git a/src/Form/LoginForm.php b/src/Form/LoginForm.php
+index 57e1fa4..bfcc8e9 100644
+--- a/src/Form/LoginForm.php
++++ b/src/Form/LoginForm.php
+@@ -75,15 +75,26 @@ class LoginForm extends FormBase implements ContainerInjectionInterface {
+         continue;
+       }
+ 
+-      $form['openid_connect_client_' . $client_id . '_login'] = [
+-        '#type' => 'submit',
+-        '#value' => t('Log in with @client_title', [
+-          '@client_title' => $client['label'],
+-        ]),
+-        '#name' => $client_id,
+-        '#prefix' => '<div>',
+-        '#suffix' => '</div>',
+-      ];
++      if ($client_id == 'keycloak') {
++        $form['openid_connect_client_' . $client_id . '_login'] = [
++          '#type' => 'submit',
++          '#value' => t('Log in with your developer account'),
++          '#name' => $client_id,
++          '#prefix' => '<div>',
++          '#suffix' => '</div>',
++        ];
++      }
++      else {
++        $form['openid_connect_client_' . $client_id . '_login'] = [
++          '#type' => 'submit',
++          '#value' => t('Log in with @client_title', [
++            '@client_title' => $client['label'],
++          ]),
++          '#name' => $client_id,
++          '#prefix' => '<div>',
++          '#suffix' => '</div>',
++        ];
++      }
+     }
+     return $form;
+   }

--- a/_docker/drupal/drupal-filesystem/composer.json
+++ b/_docker/drupal/drupal-filesystem/composer.json
@@ -128,6 +128,9 @@
           },
           "drupal/inline_entity_form": {
             "Support entity reference revisions": "https://www.drupal.org/files/issues/support_entity_revision-2367235-92.patch"
+          },
+          "drupal/openid_connect": {
+            "Change Keycloak LoginForm button text": "change-keycloak-button-text.patch"
           }
         }
     }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_drupal-user-login-form.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_drupal-user-login-form.scss
@@ -3,6 +3,5 @@
 }
 
 #block-openidconnectlogin {
-    display: none;
     @extend .container;
 }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/block--openid-connect-login.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/block--openid-connect-login.html.twig
@@ -1,0 +1,47 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{%
+  set classes = [
+    'block',
+    'block-' ~ configuration.provider|clean_class,
+    'block-' ~ plugin_id|clean_class,
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  <details>
+    <summary>Login with your developer account</summary>
+    {{ title_prefix }}
+    {% if label %}
+      <h2{{ title_attributes }}>{{ label }}</h2>
+    {% endif %}
+    {{ title_suffix }}
+    {% block content %}
+      {{ content }}
+    {% endblock %}
+  </details>
+</div>


### PR DESCRIPTION
This makes some changes to make the OpenID Connect Login button a little
more evident, but still not incredibly prominent to editors. This is
achieved by putting the button in a <details> element. Also, I created a
patch for the OpenID module to change the text of the OPenID Login
button, for only the Keycloak provider, to "Log in with your developer
account". Unfortunately, the render array for this block is being
generated in the actual Form class, as opposed to utilizing a Twig
template, so a patch to the Form class was required vs. overriding a
Twig template.

### JIRA Issue Link
* n/a