### PR TITLE
Adds debugging patch to OpenID Connect module

### DIFF
--- a/_docker/drupal/drupal-filesystem/composer.json
+++ b/_docker/drupal/drupal-filesystem/composer.json
@@ -130,7 +130,8 @@
             "Support entity reference revisions": "https://www.drupal.org/files/issues/support_entity_revision-2367235-92.patch"
           },
           "drupal/openid_connect": {
-            "Change Keycloak LoginForm button text": "change-keycloak-button-text.patch"
+            "Change Keycloak LoginForm button text": "change-keycloak-button-text.patch",
+            "Debug Complete Authorization Error": "debugging-complete-authorization-error.patch"
           }
         }
     }

--- a/_docker/drupal/drupal-filesystem/debugging-complete-authorization-error.patch
+++ b/_docker/drupal/drupal-filesystem/debugging-complete-authorization-error.patch
@@ -1,0 +1,15 @@
+diff --git a/openid_connect.module b/openid_connect.module
+index ec7a465..75580f0 100644
+--- a/openid_connect.module
++++ b/openid_connect.module
+@@ -414,6 +414,10 @@ function openid_connect_complete_authorization($client, array $tokens, &$destina
+   $user_data = $client->decodeIdToken($tokens['id_token']);
+   $userinfo = $client->retrieveUserInfo($tokens['access_token']);
+ 
++  echo '<pre>', var_dump($user_data), '</pre>';
++  echo '<pre>', var_dump($userinfo), '</pre>';
++  die();
++
+   $context = [
+     'user_data' => $user_data,
+   ];


### PR DESCRIPTION
This adds a patch for the OpenID connect module that I created to dump
the values of the $user_data and $userinfo variables during the complete
authorization hook.

### JIRA Issue Link
* n/a