### PR TITLE
Place Akamai Cache Clear Block

### DIFF
--- a/_docker/drupal/drupal-filesystem/composer.json
+++ b/_docker/drupal/drupal-filesystem/composer.json
@@ -134,6 +134,9 @@
           "drupal/inline_entity_form": {
             "Support entity reference revisions": "https://www.drupal.org/files/issues/support_entity_revision-2367235-92.patch"
           },
+          "drupal/moderation_sidebar": {
+            "Add Akamai block to moderation sidebar": "patches/add-akamai-block-to-sidebar.patch"
+          },
           "drupal/openid_connect": {
             "Change Keycloak LoginForm button text": "patches/change-keycloak-button-text.patch"
           }

--- a/_docker/drupal/drupal-filesystem/composer.lock
+++ b/_docker/drupal/drupal-filesystem/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9cb2707e5d16a851e8c50d7fc67ed796",
+    "content-hash": "942c5bbea4d667d77be7d3eb70217b07",
     "packages": [
         {
             "name": "acquia/lightning",
@@ -2138,7 +2138,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.25",
-                    "datestamp": "1542915384",
+                    "datestamp": "1542915180",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2538,7 +2538,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -3035,10 +3035,6 @@
                     "role": "Maintainer"
                 },
                 {
-                    "name": "joelpittet",
-                    "homepage": "https://www.drupal.org/user/160302"
-                },
-                {
                     "name": "merlinofchaos",
                     "homepage": "https://www.drupal.org/user/26979"
                 },
@@ -3080,16 +3076,12 @@
                 },
                 "drupal": {
                     "version": "8.x-3.0",
-                    "datestamp": "1493401742",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1493401742"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -3111,10 +3103,6 @@
                 {
                     "name": "japerry",
                     "homepage": "https://www.drupal.org/user/45640"
-                },
-                {
-                    "name": "joelpittet",
-                    "homepage": "https://www.drupal.org/user/160302"
                 },
                 {
                     "name": "merlinofchaos",
@@ -3349,7 +3337,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -3630,16 +3618,8 @@
                     "homepage": "https://www.drupal.org/user/3260690"
                 },
                 {
-                    "name": "Wim Leers",
-                    "homepage": "https://www.drupal.org/user/99777"
-                },
-                {
                     "name": "cs_shadow",
                     "homepage": "https://www.drupal.org/user/2828287"
-                },
-                {
-                    "name": "phenaproxima",
-                    "homepage": "https://www.drupal.org/user/205645"
                 },
                 {
                     "name": "slashrsm",
@@ -3797,7 +3777,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.x-dev",
-                    "datestamp": "1536238980",
+                    "datestamp": "1536176580",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -4370,7 +4350,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.1",
-                    "datestamp": "1547666880",
+                    "datestamp": "1545253380",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4497,7 +4477,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.4",
-                    "datestamp": "1547665680",
+                    "datestamp": "1544033580",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4632,7 +4612,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.5",
-                    "datestamp": "1547668680",
+                    "datestamp": "1545263881",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4779,7 +4759,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.4",
-                    "datestamp": "1547671380",
+                    "datestamp": "1545267780",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4908,7 +4888,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.2",
-                    "datestamp": "1547671980",
+                    "datestamp": "1545276780",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5022,7 +5002,7 @@
                 },
                 "drupal": {
                     "version": "8.x-5.0-beta7",
-                    "datestamp": "1545966784",
+                    "datestamp": "1520552585",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -5087,16 +5067,20 @@
             ],
             "authors": [
                 {
+                    "name": "barraponto",
+                    "homepage": "https://www.drupal.org/user/511760"
+                },
+                {
                     "name": "frjo",
                     "homepage": "https://www.drupal.org/user/5546"
                 },
                 {
-                    "name": "gisle",
-                    "homepage": "https://www.drupal.org/user/409554"
+                    "name": "justin2pin",
+                    "homepage": "https://www.drupal.org/user/278450"
                 },
                 {
-                    "name": "markcarver",
-                    "homepage": "https://www.drupal.org/user/501638"
+                    "name": "sreynen",
+                    "homepage": "https://www.drupal.org/user/109890"
                 }
             ],
             "description": "Allows content to be submitted using Markdown, a simple plain-text syntax that is transformed into valid HTML.",
@@ -5374,7 +5358,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha1",
-                    "datestamp": "1541456281",
+                    "datestamp": "1537899180",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -5429,6 +5413,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "Add Akamai block to moderation sidebar": "patches/add-akamai-block-to-sidebar.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -6911,7 +6898,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.12",
-                    "datestamp": "1542505221",
+                    "datestamp": "1523203180",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6992,10 +6979,6 @@
                 {
                     "name": "gausarts",
                     "homepage": "https://www.drupal.org/user/159062"
-                },
-                {
-                    "name": "thalles",
-                    "homepage": "https://www.drupal.org/user/3589086"
                 }
             ],
             "description": "Slick carousel, the last carousel you'll ever need.",
@@ -7474,7 +7457,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -8787,7 +8770,7 @@
                 {
                     "name": "Luís Otávio Cobucci Oblonczyk",
                     "email": "lcobucci@gmail.com",
-                    "role": "Developer"
+                    "role": "developer"
                 }
             ],
             "description": "A simple library to work with JSON Web Token and JSON Web Signature",
@@ -11100,7 +11083,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -13284,6 +13267,12 @@
                 "type": "git",
                 "url": "https://git.drupal.org/project/coder.git",
                 "reference": "984c54a7b1e8f27ff1c32348df69712afd86b17f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/klausi/coder/zipball/984c54a7b1e8f27ff1c32348df69712afd86b17f",
+                "reference": "984c54a7b1e8f27ff1c32348df69712afd86b17f",
+                "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",

--- a/_docker/drupal/drupal-filesystem/patches/add-akamai-block-to-sidebar.patch
+++ b/_docker/drupal/drupal-filesystem/patches/add-akamai-block-to-sidebar.patch
@@ -1,0 +1,83 @@
+diff --git a/src/Controller/ModerationSidebarController.php b/src/Controller/ModerationSidebarController.php
+index 50cc17e..f9ea66e 100644
+--- a/src/Controller/ModerationSidebarController.php
++++ b/src/Controller/ModerationSidebarController.php
+@@ -4,6 +4,7 @@ namespace Drupal\moderation_sidebar\Controller;
+ 
+ use Drupal\Component\Utility\Xss;
+ use Drupal\content_moderation\ModerationInformation;
++use Drupal\Core\Block\BlockManager;
+ use Drupal\Core\Controller\ControllerBase;
+ use Drupal\Core\Datetime\DateFormatterInterface;
+ use Drupal\Core\Entity\ContentEntityInterface;
+@@ -61,6 +62,13 @@ class ModerationSidebarController extends ControllerBase {
+    */
+   protected $localTaskManager;
+ 
++  /**
++   * The block manager.
++   *
++   * @var \Drupal\Core\Block\BlockManager
++   */
++  protected $blockManager;
++
+   /**
+    * Creates a ModerationSidebarController instance.
+    *
+@@ -74,13 +82,16 @@ class ModerationSidebarController extends ControllerBase {
+    *   The module handler service.
+    * @param \Drupal\Core\Menu\LocalTaskManagerInterface $local_task_manager
+    *   The local task manager.
++   * @param \Drupal\Core\Block\BlockManager $block_manager
++   *   The block manager.
+    */
+-  public function __construct(ModerationInformation $moderation_information, RequestStack $request_stack, DateFormatterInterface $date_formatter, ModuleHandlerInterface $module_handler, LocalTaskManagerInterface $local_task_manager) {
++  public function __construct(ModerationInformation $moderation_information, RequestStack $request_stack, DateFormatterInterface $date_formatter, ModuleHandlerInterface $module_handler, LocalTaskManagerInterface $local_task_manager, BlockManager $block_manager) {
+     $this->moderationInformation = $moderation_information;
+     $this->request = $request_stack->getCurrentRequest();
+     $this->dateFormatter = $date_formatter;
+     $this->moduleHandler = $module_handler;
+     $this->localTaskManager = $local_task_manager;
++    $this->blockManager = $block_manager;
+   }
+ 
+   /**
+@@ -121,12 +132,15 @@ class ModerationSidebarController extends ControllerBase {
+       $container->get('current_user')
+     );
+ 
++    $block_manager = $container->get('plugin.manager.block');
++
+     return new static(
+       $moderation_info,
+       $request_stack,
+       $container->get('date.formatter'),
+       $container->get('module_handler'),
+-      $local_task_manager
++      $local_task_manager,
++      $block_manager
+     );
+   }
+ 
+@@ -215,6 +229,21 @@ class ModerationSidebarController extends ControllerBase {
+         ];
+       }
+ 
++      // Display the Akamai cache clear block if present.
++      if ($this->moduleHandler->moduleExists('akamai')) {
++		$config = [];
++		$plugin_block = $this->blockManager->createInstance('akamai_cache_clear_block', $config);
++		$access_result = $plugin_block->access(\Drupal::currentUser());
++		// Return empty render array if user doesn't have access.
++		// $access_result can be boolean or an AccessResult class
++		if (is_object($access_result) && $access_result->isForbidden() || is_bool($access_result) && !$access_result) {
++		  return [];
++		}
++
++        // Add the render array for the Akamai block to the sidebar.
++        $build['actions']['akamai_cache_clear'] = $plugin_block->build();
++      }
++
+       // Show an edit link if this is the latest revision.
+       if ($is_latest && $entity->access('update')) {
+         $build['actions']['edit'] = [

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_akamai-block.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_akamai-block.scss
@@ -1,0 +1,3 @@
+.akamai-clear-url-form .form-item-message {
+  display: none;
+}


### PR DESCRIPTION
This commit introduces and applies a patch to the moderation_sidebar
contrib module that first verifies that the Akamai module is installed
and, if it is, then places the Akamai cache clear plugin block in the
moderation sidebar. I also added a one line SCSS rule `display: none` to
a div element that displayed the Refresh URL, which I thought was
unnecessary clutter visually.

### JIRA Issue Link
* https://issues.jboss.org/browse/RHDENG-2463

### Verification Process

The Akamai cache clear block is placed within the moderation sidebar like so:

<img width="1635" alt="screen shot 2019-01-25 at 1 02 33 pm" src="https://user-images.githubusercontent.com/7155034/51772700-82ee7580-20a1-11e9-90f6-6157b3243f56.png">

