### PR TITLE
DEVELOPER-5628: Display Status Messages Login Page

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.openidconnectlogin.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.openidconnectlogin.yml
@@ -10,7 +10,7 @@ dependencies:
 id: openidconnectlogin
 theme: rhdp
 region: content
-weight: -9
+weight: -8
 provider: null
 plugin: openid_connect_login
 settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.rhdp_content.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.rhdp_content.yml
@@ -9,7 +9,7 @@ dependencies:
 id: rhdp_content
 theme: rhdp
 region: content
-weight: -8
+weight: -7
 provider: null
 plugin: system_main_block
 settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.rhdp_messages.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.rhdp_messages.yml
@@ -8,8 +8,8 @@ dependencies:
     - rhdp
 id: rhdp_messages
 theme: rhdp
-region: title
-weight: -3
+region: content
+weight: -9
 provider: null
 plugin: system_messages_block
 settings:
@@ -17,4 +17,9 @@ settings:
   label: 'Status messages'
   provider: system
   label_display: '0'
-visibility: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: '/user/*'
+    negate: false
+    context_mapping: {  }

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.views_block__connectors_rest_export_connectors_rest_export_block.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.views_block__connectors_rest_export_connectors_rest_export_block.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__connectors_rest_export_connectors_rest_export_block
 theme: rhdp
 region: content
-weight: -7
+weight: -6
 provider: null
 plugin: 'views_block:connectors_rest_export-connectors_rest_export_block'
 settings:

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_drupal-user-login-form.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_drupal-user-login-form.scss
@@ -5,3 +5,7 @@
 #block-openidconnectlogin {
     @extend .container;
 }
+
+.page-user-login .messages {
+    @extend .container;
+}

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/system/page--user.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/system/page--user.html.twig
@@ -1,0 +1,83 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a single page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - messages: Status and error messages. Should be displayed prominently.
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.footer: Items for the footer region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ *
+ * @ingroup themeable
+ */
+#}
+{% set nav_type = is_front ? ' front-nav' : '' %}
+<div class="layout-container">
+
+  <header role="banner">
+    <div class="rhd-masthead{{ nav_type }}">
+      {{ page.rh_universal_header }}
+      <div class="container">
+        <div class="rhd-masthead-inner">
+          {{ page.rhd_header }}
+          {{ page.mobile_tray }}
+          <div class="menu-toggle-wrapper">
+            <button class="menu-toggle">Menu<span class="icon"><i class="far fa-bars"></i></span></button>
+          </div>
+        </div>
+      </div>
+      {{ page.rhd_post_header }}
+    </div>
+  </header>
+  <div class="rhd-mobile-overlay"></div>
+  <div class="rhd-search-toggle-overlay"></div>
+
+  <main role="main">
+    <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
+
+    <div class="layout-content">
+      {{ page.content }}
+    </div>{# /.layout-content #}
+  </main>
+
+  {% if page.rhd_footer %}
+    <footer role="contentinfo">
+      {{ page.rhd_footer }}
+    </footer>
+  {% endif %}
+
+</div>{# /.layout-container #}


### PR DESCRIPTION
This commit places the status messages block into the Content region and
sets the visibility conditions such that it displays only on /user/*
routes. I also added some CSS so that the status messages would respect
the same CSS container as the rest of the content in that region.

### JIRA Issue Link
* https://issues.jboss.org/browse/DEVELOPER-5628

### Verification Process

Go here: /user/login

Do this:

* Log in with your username but enter an incorrect password

You should see this:

* You are not authenticated, but you see an error message (likely "Unrecognized username or password. Forgot your password?")