### PR TITLE
MWES-2463: Akamai Block Styles

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.akamaicacheclear.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.akamaicacheclear.yml
@@ -1,0 +1,35 @@
+uuid: 419d62a1-64b8-4317-a2a0-befe74e7e470
+langcode: en
+status: true
+dependencies:
+  module:
+    - akamai
+    - user
+  theme:
+    - rhdp
+id: akamaicacheclear
+theme: rhdp
+region: rh_universal_header
+weight: -8
+provider: null
+plugin: akamai_cache_clear_block
+settings:
+  id: akamai_cache_clear_block
+  label: 'Akamai Cache Clear'
+  provider: akamai
+  label_display: '0'
+visibility:
+  user_role:
+    id: user_role
+    roles:
+      media_manager: media_manager
+      layout_manager: layout_manager
+      content_creator: content_creator
+      content_team: content_team
+      content_admin: content_admin
+      coding_resource_creator: coding_resource_creator
+      coding_resource_reviewer: coding_resource_reviewer
+      administrator: administrator
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.universalheader.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.universalheader.yml
@@ -11,7 +11,7 @@ dependencies:
 id: universalheader
 theme: rhdp
 region: rh_universal_header
-weight: 0
+weight: -9
 provider: null
 plugin: 'system_menu_block:universal-header'
 settings:

--- a/_docker/drupal/drupal-filesystem/web/config/sync/block.block.useraccountmenu.yml
+++ b/_docker/drupal/drupal-filesystem/web/config/sync/block.block.useraccountmenu.yml
@@ -11,7 +11,7 @@ dependencies:
 id: useraccountmenu
 theme: rhdp
 region: rh_universal_header
-weight: 0
+weight: -7
 provider: null
 plugin: 'system_menu_block:account'
 settings:

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_akamai-block.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_akamai-block.scss
@@ -1,3 +1,14 @@
-.akamai-clear-url-form .form-item-message {
-  display: none;
+.akamai-clear-url-form {
+  margin: 0;
+
+  .form-item-message {
+    display: none;
+  }
+
+  .button {
+    font-size: 12px;
+    padding: 9px 20px;
+  }
 }
+
+

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_navigation.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_navigation.scss
@@ -24,7 +24,7 @@
   @include desktop-small {
     max-width: 1400px;
     grid-column-gap: 0;
-    grid-template-columns: 145px 1fr;
+    grid-template-columns: 145px 1fr 185px;
   }
   @media screen and (max-width: 991px) and (min-width: 768px) {
     max-width: none;

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/rhd.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/rhd.scss
@@ -65,6 +65,9 @@
 //drupal admin override
 @import "drupal-user-login-form";
 
+// Drupal Akamai cache clear block styles
+@import "akamai-block";
+
 [data-rhd-grid="normal"] {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
This places the Akamai Block in the topmost header region and adds some
CSS styles to make the presentation of the block more appealing and
appropriate given the surrounding design/context.

I was unable to build the CSS from the SCSS files locally/in Docker, so
I will have to review this closely once the styles build in the PR
environment or managed platform.

### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-2463

### Verification Process

<img width="1417" alt="screen shot 2019-02-06 at 12 01 08 pm" src="https://user-images.githubusercontent.com/7155034/52371682-0e092d00-2a0b-11e9-8c06-4f56d2c2b55e.png">

Authenticated users with one of the following roles: Media Manager, Layout manager, Content Creator, Content Reviewer, Content Admin, Coding Resource creator, Coding Resource reviewer, Administrator

should now see the Akamai cache clear block in the topmost header of the website.

Upon clicking the button, the user should be redirected to the same page they were on prior to clicking the button, and they should see a status message like "Asked Akamai to purge /training" in the screenshot below.

<img width="1659" alt="screen shot 2019-02-06 at 12 28 19 pm" src="https://user-images.githubusercontent.com/7155034/52371681-0e092d00-2a0b-11e9-8542-ef6355748b15.png">

I do not think that the "Section "default" does not exist!" status message will arise on a site that is properly configured to post to Akamai.

We should be able to confirm that routes are successfully purged from Akamai.