### PR TITLE
[MWES-2760] Login page display SSO block

### DIFF
--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/drupal-user-login-form.js
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/scripts/@rhd/js/drupal-user-login-form.js
@@ -1,0 +1,14 @@
+// Opens in a new tab all (except Download Manager) links ending in .pdf extension
+$(document).ready(function() {
+  $("#drupalUserLoginToggleVisibility").click(function() {
+    $('#user-login-form').toggle();
+    if ($(this).text().startsWith('Reveal')) {
+      var replacement = $(this).text().replace('Reveal', 'Hide');
+      $(this).text(replacement);
+    }
+    else if ($(this).text().startsWith('Hide')) {
+      var replacement = $(this).text().replace('Hide', 'Reveal');
+      $(this).text(replacement);
+    }
+  })
+});

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_drupal-user-login-form.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_drupal-user-login-form.scss
@@ -4,6 +4,7 @@
 
 #block-openidconnectlogin {
     @extend .container;
+    margin: 30px auto;
 }
 
 #edit-openid-connect-client-keycloak-login.button {

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_drupal-user-login-form.scss
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/rhd-frontend/src/styles/_drupal-user-login-form.scss
@@ -6,6 +6,14 @@
     @extend .container;
 }
 
+#edit-openid-connect-client-keycloak-login.button {
+    margin: 0 auto;
+}
+
+#user-login-form {
+    display: none;
+}
+
 .page-user-login .messages {
     @extend .container;
 }

--- a/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/block--openid-connect-login.html.twig
+++ b/_docker/drupal/drupal-filesystem/web/themes/custom/rhdp/templates/block--openid-connect-login.html.twig
@@ -33,15 +33,14 @@
   ]
 %}
 <div{{ attributes.addClass(classes) }}>
-  <details>
-    <summary>Login with your developer account</summary>
-    {{ title_prefix }}
-    {% if label %}
-      <h2{{ title_attributes }}>{{ label }}</h2>
-    {% endif %}
-    {{ title_suffix }}
-    {% block content %}
-      {{ content }}
-    {% endblock %}
-  </details>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  <p>Content editors should now log in by clicking this button, which will direct you to log in with your Keycloak credentials. Please ensure you use a Keycloak account that is associated to the same email address you have associated to your Drupal account. For assistance, please contact the RHD developers at Rhd-drupal-admin@redhat.com.</p>
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+  <button id="drupalUserLoginToggleVisibility">Reveal old login form</button>
 </div>


### PR DESCRIPTION
### JIRA Issue Link
* https://issues.jboss.org/browse/MWES-2760

### Verification Process

It should look like this:

<img width="1295" alt="screen shot 2019-02-06 at 4 03 01 pm" src="https://user-images.githubusercontent.com/7155034/52382155-09ec0800-2a29-11e9-9b77-d7b5986c7d16.png">


When you click on the 'Reveal...' button, it should reveal the default Drupal login form and the text of the button should change to 'Hide...'.